### PR TITLE
Turn SignColumn to a link to LineNr

### DIFF
--- a/colors/mojave.vim
+++ b/colors/mojave.vim
@@ -44,7 +44,6 @@ hi DiffAdd        term=bold ctermfg=16 ctermbg=40 guifg=#000000 guibg=#33cc33
 hi DiffChange     term=bold ctermfg=16 ctermbg=44 guifg=#000000 guibg=#33cccc
 hi DiffDelete     term=bold ctermfg=231 ctermbg=160 gui=bold guifg=#ffffff guibg=#cc3333
 hi DiffText       term=reverse cterm=bold ctermfg=231 ctermbg=20 gui=bold guifg=#ffffff guibg=#3333cc
-hi SignColumn     term=standout ctermfg=14 ctermbg=242 guifg=Cyan guibg=Grey
 hi Conceal        ctermfg=7 ctermbg=242 guifg=LightGrey guibg=DarkGrey
 hi SpellBad       term=reverse ctermbg=9 gui=undercurl guisp=Red
 hi SpellCap       term=reverse ctermbg=12 gui=undercurl guisp=Blue
@@ -72,3 +71,5 @@ hi Type           ctermfg=143 guifg=#bdb76b
 hi Special        ctermfg=223 guifg=#ffdead
 hi Ignore         ctermfg=240 guifg=#666666
 hi Todo           ctermfg=196 ctermbg=226 guifg=#ff4500 guibg=#eeee00
+
+highlight! default link SignColumn LineNr


### PR DESCRIPTION
This is mainly to paper over a change in behaviour on GitGutter.

https://github.com/airblade/vim-gitgutter/commit/0da302c28a08fe62c31c77ac854914affd2180b8

Here's how it looks without this change:

![2020-05-05T01:16:34+01:00](https://user-images.githubusercontent.com/1750665/81027443-afcd3300-8e75-11ea-83ef-700eb2fe6478.png)


I tried `hi default link SignColumn LineNr` (no `!`) but that did not work.

`:verbose hi SignColumn` shows it changed on line 15, which is the reset.